### PR TITLE
Connect project actions to backend

### DIFF
--- a/frontend/src/stores/projectStore.test.ts
+++ b/frontend/src/stores/projectStore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useProjectStore } from './projectStore'
+import { useOrganizationStore } from './organizationStore'
+import { apolloClient } from '@/graphql/client'
+
+vi.mock('@/graphql/client', () => ({
+  apolloClient: {
+    query: vi.fn(),
+    mutate: vi.fn(),
+  },
+}))
+
+describe('projectStore actions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    const org = useOrganizationStore()
+    org.setOrganization({ id: 'org1', name: 'Org 1' })
+    vi.resetAllMocks()
+  })
+
+  it('creates a project and updates state', async () => {
+    ;(apolloClient.mutate as any).mockResolvedValue({
+      data: { createProject: { id: '1', name: 'Test', status: 'ACTIVE' } },
+    })
+    const store = useProjectStore()
+    await store.createProject({ name: 'Test' })
+    expect(store.projects.length).toBe(1)
+    expect(store.projects[0].name).toBe('Test')
+    expect(store.error).toBeNull()
+  })
+
+  it('archives a project', async () => {
+    const store = useProjectStore()
+    store.projects = [{ id: '1', name: 'Test', status: 'ACTIVE' }]
+    ;(apolloClient.mutate as any).mockResolvedValue({
+      data: { updateProject: { id: '1', name: 'Test', status: 'ARCHIVED' } },
+    })
+    await store.archiveProject('1')
+    expect(store.projects[0].status).toBe('ARCHIVED')
+  })
+
+  it('sets error on delete failure', async () => {
+    const store = useProjectStore()
+    store.projects = [{ id: '1', name: 'Test', status: 'ACTIVE' }]
+    ;(apolloClient.mutate as any).mockRejectedValue(new Error('fail'))
+    await expect(store.deleteProject('1')).rejects.toThrow('fail')
+    expect(store.error).toBe('fail')
+    expect(store.projects.length).toBe(1)
+  })
+})

--- a/frontend/src/stores/projectStore.ts
+++ b/frontend/src/stores/projectStore.ts
@@ -1,19 +1,71 @@
 import { defineStore } from 'pinia'
+import { useOrganizationStore } from '@/stores/organizationStore'
+import { apolloClient } from '@/graphql/client'
+import gql from 'graphql-tag'
+
+export interface Project {
+  id: string
+  name: string
+  status: string
+  description?: string | null
+}
 
 interface ProjectState {
   currentProjectId: string | null
   currentBranch: string
+  projects: Project[]
+  error: string | null
 }
+
+const LIST_PROJECTS = gql`
+  query Projects($orgId: ID!) {
+    projects(filter: { status: "ACTIVE" }, limit: 100, offset: 0) {
+      id
+      name
+      status
+      description
+    }
+  }
+`
+
+const CREATE_PROJECT = gql`
+  mutation CreateProject($input: CreateProjectInput!) {
+    createProject(input: $input) {
+      id
+      name
+      status
+      description
+    }
+  }
+`
+
+const UPDATE_PROJECT = gql`
+  mutation UpdateProject($input: UpdateProjectInput!) {
+    updateProject(input: $input) {
+      id
+      name
+      status
+      description
+    }
+  }
+`
+
+const DELETE_PROJECT = gql`
+  mutation DeleteProject($id: ID!, $orgId: ID!) {
+    deleteProject(id: $id, orgId: $orgId)
+  }
+`
 
 export const useProjectStore = defineStore('project', {
   state: (): ProjectState => ({
     currentProjectId: null,
     currentBranch: 'main',
+    projects: [],
+    error: null,
   }),
   actions: {
     setProject(id: string | null) {
       this.currentProjectId = id
-      // Store in localStorage for persistence
       if (id) {
         localStorage.setItem('olivine-current-project', id)
       } else {
@@ -23,18 +75,93 @@ export const useProjectStore = defineStore('project', {
     setBranch(name: string) {
       this.currentBranch = name
     },
+    async fetchProjects() {
+      try {
+        const orgId = useOrganizationStore().currentOrg?.id
+        if (!orgId) throw new Error('Organization not selected')
+        const { data } = await apolloClient.query({
+          query: LIST_PROJECTS,
+          variables: { orgId },
+          fetchPolicy: 'no-cache',
+        })
+        this.projects = data.projects || []
+        this.error = null
+      } catch (e: any) {
+        this.error = e.message || 'Unknown error'
+        throw e
+      }
+    },
+    async createProject(input: { name: string; description?: string; settings?: any }) {
+      try {
+        const orgId = useOrganizationStore().currentOrg?.id
+        if (!orgId) throw new Error('Organization not selected')
+        const { data } = await apolloClient.mutate({
+          mutation: CREATE_PROJECT,
+          variables: { input: { orgId, ...input } },
+        })
+        this.projects.push(data.createProject)
+        this.error = null
+        return data.createProject as Project
+      } catch (e: any) {
+        this.error = e.message || 'Unknown error'
+        throw e
+      }
+    },
+    async editProject(id: string, name: string) {
+      try {
+        const orgId = useOrganizationStore().currentOrg?.id
+        if (!orgId) throw new Error('Organization not selected')
+        const { data } = await apolloClient.mutate({
+          mutation: UPDATE_PROJECT,
+          variables: { input: { id, orgId, name } },
+        })
+        const idx = this.projects.findIndex(p => p.id === id)
+        if (idx !== -1) this.projects[idx] = data.updateProject
+        this.error = null
+        return data.updateProject as Project
+      } catch (e: any) {
+        this.error = e.message || 'Unknown error'
+        throw e
+      }
+    },
+    async archiveProject(id: string) {
+      try {
+        const orgId = useOrganizationStore().currentOrg?.id
+        if (!orgId) throw new Error('Organization not selected')
+        const { data } = await apolloClient.mutate({
+          mutation: UPDATE_PROJECT,
+          variables: { input: { id, orgId, status: 'ARCHIVED' } },
+        })
+        const idx = this.projects.findIndex(p => p.id === id)
+        if (idx !== -1) this.projects[idx] = data.updateProject
+        this.error = null
+        return data.updateProject as Project
+      } catch (e: any) {
+        this.error = e.message || 'Unknown error'
+        throw e
+      }
+    },
+    async deleteProject(id: string) {
+      try {
+        const orgId = useOrganizationStore().currentOrg?.id
+        if (!orgId) throw new Error('Organization not selected')
+        await apolloClient.mutate({
+          mutation: DELETE_PROJECT,
+          variables: { id, orgId },
+        })
+        this.projects = this.projects.filter(p => p.id !== id)
+        if (this.currentProjectId === id) this.setProject(null)
+        this.error = null
+      } catch (e: any) {
+        this.error = e.message || 'Unknown error'
+        throw e
+      }
+    },
     initializeProject() {
-      // Try to restore from localStorage first
       const storedProjectId = localStorage.getItem('olivine-current-project')
       if (storedProjectId) {
         this.currentProjectId = storedProjectId
-        return
       }
-      
-      // If no stored project, set a default project for demo purposes
-      // In a real app, this would check if projects exist via API
-      const defaultProjectId = 'demo-project-1'
-      this.setProject(defaultProjectId)
     },
   },
 })


### PR DESCRIPTION
## Summary
- implement GraphQL-powered project store with fetch, create, update, archive and delete actions
- wire Projects view to new store actions for editing, archiving, creating and deleting projects
- add unit tests covering project store actions and error handling

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_689bc635a274832f887f9982a359841f