### PR TITLE
Add backend TypeScript type-check pretest

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
 
     "dev": "nodemon --exec ts-node src/index.ts",
     "start": "node dist/index.js",
+    "pretest": "npm run type-check",
     "test": "jest",
     "test:unit": "jest --selectProjects unit",
     "test:integration": "jest --selectProjects integration",
@@ -21,7 +22,8 @@
     "lint:fix": "eslint src/**/*.ts --fix",
     "migrate": "ts-node src/scripts/migrate.ts",
     "test:setup": "ts-node src/tests/globalSetup.ts",
-    "test:teardown": "ts-node src/tests/globalTeardown.ts"
+    "test:teardown": "ts-node src/tests/globalTeardown.ts",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@apollo/server": "^5.0.0",


### PR DESCRIPTION
## Summary
- run TypeScript compiler without emitting before tests
- ensure `npm test` triggers type checking via npm's `pretest` script

## Testing
- `npm run type-check`
- `npx jest --runTestsByPath nonexistent.test.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689bdfdc11d0832f99a63cf66faa40d7