### PR TITLE
feat: add notification system

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,15 @@
 <template>
   <v-app>
-    <AppHeader @toggle-drawer="drawer = !drawer" />
+    <AppHeader @toggle-drawer="drawer = !drawer">
+      <template #actions>
+        <NotificationBell />
+      </template>
+    </AppHeader>
     <AppSidebar v-model:open="drawer" />
     <PageContainer>
       <router-view />
     </PageContainer>
+    <ToastContainer />
   </v-app>
 </template>
 
@@ -13,6 +18,8 @@ import { ref, onMounted } from 'vue'
 import AppHeader from '@components/layout/AppHeader.vue'
 import AppSidebar from '@components/layout/AppSidebar.vue'
 import PageContainer from '@components/layout/PageContainer.vue'
+import NotificationBell from '@components/layout/NotificationBell.vue'
+import ToastContainer from '@components/common/ToastContainer.vue'
 import { useProjectStore } from '@/stores/projectStore'
 
 const drawer = ref(true)

--- a/frontend/src/components/common/ToastContainer.vue
+++ b/frontend/src/components/common/ToastContainer.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-snackbar
+    v-model="visible"
+    :color="current?.level"
+    location="bottom right"
+    timeout="5000"
+  >
+    <div>{{ current?.message }}</div>
+    <template #actions>
+      <v-btn icon @click="visible = false">
+        <v-icon>mdi-close</v-icon>
+      </v-btn>
+    </template>
+  </v-snackbar>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useNotificationStore, type NotificationItem } from '@/stores/notificationStore'
+
+const store = useNotificationStore()
+const visible = ref(false)
+const current = ref<NotificationItem | null>(null)
+const lastId = ref<string | undefined>()
+
+watch(
+  () => store.items[0],
+  (item) => {
+    if (item && item.id !== lastId.value) {
+      current.value = item
+      visible.value = true
+      lastId.value = item.id
+    }
+  }
+)
+</script>

--- a/frontend/src/components/layout/NotificationBell.vue
+++ b/frontend/src/components/layout/NotificationBell.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-menu v-model="menu" location="bottom end">
+    <template #activator="{ props }">
+      <v-btn v-bind="props" icon>
+        <v-badge v-if="unread > 0" :content="unread" color="error" overlap>
+          <v-icon>mdi-bell</v-icon>
+        </v-badge>
+        <v-icon v-else>mdi-bell</v-icon>
+      </v-btn>
+    </template>
+    <v-list style="min-width: 300px">
+      <v-list-item v-for="item in items" :key="item.id" @click="open(item)">
+        <v-list-item-title :class="{ 'font-weight-medium': !item.read }">
+          {{ item.message }}
+        </v-list-item-title>
+        <v-list-item-subtitle>{{ formatDate(item.createdAt) }}</v-list-item-subtitle>
+      </v-list-item>
+      <v-list-item v-if="items.length === 0" title="No notifications" />
+      <v-divider />
+      <v-list-item>
+        <v-btn variant="text" @click="clear">Clear All</v-btn>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useNotificationStore, type NotificationItem } from '@/stores/notificationStore'
+import { useRouter } from 'vue-router'
+
+const menu = ref(false)
+const store = useNotificationStore()
+const router = useRouter()
+
+const items = store.items
+const unread = store.unreadCount
+
+function open(item: NotificationItem) {
+  store.markRead(item.id)
+  menu.value = false
+  if (item.link) router.push(item.link)
+}
+
+function clear() {
+  store.clear()
+}
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleString()
+}
+
+watch(menu, (v) => {
+  if (v) store.markAllRead()
+})
+</script>

--- a/frontend/src/stores/notificationStore.ts
+++ b/frontend/src/stores/notificationStore.ts
@@ -8,6 +8,7 @@ export interface NotificationItem {
   message: string
   createdAt: string
   link?: string
+  read: boolean
 }
 
 interface NotificationState {
@@ -18,6 +19,7 @@ export const useNotificationStore = defineStore('notifications', {
   state: (): NotificationState => ({ items: [] }),
   getters: {
     count: (state) => state.items.length,
+    unreadCount: (state) => state.items.filter((i) => !i.read).length,
   },
   actions: {
     add(level: NotificationLevel, message: string, link?: string) {
@@ -27,12 +29,21 @@ export const useNotificationStore = defineStore('notifications', {
         message,
         link,
         createdAt: new Date().toISOString(),
+        read: false,
       })
+    },
+    markRead(id: string) {
+      const item = this.items.find((i) => i.id === id)
+      if (item) item.read = true
+    },
+    markAllRead() {
+      this.items.forEach((i) => (i.read = true))
+    },
+    remove(id: string) {
+      this.items = this.items.filter((i) => i.id !== id)
     },
     clear() {
       this.items = []
     },
   },
 })
-
-

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -2,16 +2,51 @@
   <div>
     <h2>Notifications & Inbox</h2>
     <v-card>
-      <v-list density="compact">
-        <v-list-item v-for="n in notifications" :key="n.id" :title="n.message" :subtitle="n.createdAt" />
+      <v-list density="comfortable">
+        <v-list-item
+          v-for="n in notifications"
+          :key="n.id"
+          @click="open(n)"
+        >
+          <v-list-item-title :class="{ 'font-weight-medium': !n.read }">
+            {{ n.message }}
+          </v-list-item-title>
+          <v-list-item-subtitle>{{ formatDate(n.createdAt) }}</v-list-item-subtitle>
+          <template #append>
+            <v-btn icon="mdi-close" @click.stop="remove(n.id)" />
+          </template>
+        </v-list-item>
+        <v-list-item v-if="notifications.length === 0" title="No notifications" />
       </v-list>
+      <v-card-actions>
+        <v-btn variant="text" @click="clear">Clear All</v-btn>
+      </v-card-actions>
     </v-card>
   </div>
 </template>
 
 <script setup lang="ts">
-import { useNotificationStore } from '@/stores/notificationStore'
-const notifications = useNotificationStore().items
+import { useNotificationStore, type NotificationItem } from '@/stores/notificationStore'
+import { useRouter } from 'vue-router'
+
+const store = useNotificationStore()
+const router = useRouter()
+const notifications = store.items
+
+function open(n: NotificationItem) {
+  store.markRead(n.id)
+  if (n.link) router.push(n.link)
+}
+
+function remove(id: string) {
+  store.remove(id)
+}
+
+function clear() {
+  store.clear()
+}
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleString()
+}
 </script>
-
-


### PR DESCRIPTION
## Summary
- add toast container to show in-app snackbars
- add notification bell with unread count and dropdown list
- expand notification store with read and clear actions and build inbox view

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails: vue-tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd3783184832fa61cb793b794a386