### PR TITLE
Add splash page and auth registration flow

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import { TaxonomyClassificationAgent } from './agents/TaxonomyClassificationAgen
 import { ProvenanceTrackingAgent } from './agents/ProvenanceTrackingAgent';
 import { SyncAgent } from './agents/SyncAgent';
 import oauthRoutes from './routes/oauthRoutes';
+import authRoutes from './routes/authRoutes';
 import { GraphQLServer } from './graphql/server';
 
 // Load environment variables
@@ -39,6 +40,7 @@ app.use(cors({
 app.use(helmet());
 app.use(express.json());
 app.use('/api/oauth', oauthRoutes);
+app.use('/api/auth', authRoutes);
 
 // Initialize webhook handlers (will be created after queueService is instantiated)
 
@@ -110,6 +112,7 @@ async function startServer() {
     app.use(helmet());
     app.use(express.json());
     app.use('/api/oauth', oauthRoutes);
+    app.use('/api/auth', authRoutes);
     
     // Initialize webhook handlers (will be created after queueService is instantiated)
     const dropboxWebhookHandler = new DropboxWebhookHandler(queueService);

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { AuthService } from '../services/AuthService';
+
+const router = Router();
+const authService = new AuthService();
+
+router.post('/register', async (req, res) => {
+  const { orgName, email, password } = req.body;
+  if (!orgName || !email || !password) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+  try {
+    const result = await authService.register(orgName, email, password);
+    return res.json(result);
+  } catch (err) {
+    return res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+  try {
+    const result = await authService.authenticateUser(email, password);
+    if (!result) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    return res.json(result);
+  } catch (err) {
+    return res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+export default router;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,20 +1,23 @@
 <template>
   <v-app>
-    <AppHeader @toggle-drawer="drawer = !drawer">
-      <template #actions>
-        <NotificationBell />
-      </template>
-    </AppHeader>
-    <AppSidebar v-model:open="drawer" />
-    <PageContainer>
-      <router-view />
-    </PageContainer>
-    <ToastContainer />
+    <template v-if="showAppShell">
+      <AppHeader @toggle-drawer="drawer = !drawer">
+        <template #actions>
+          <NotificationBell />
+        </template>
+      </AppHeader>
+      <AppSidebar v-model:open="drawer" />
+      <PageContainer>
+        <router-view />
+      </PageContainer>
+      <ToastContainer />
+    </template>
+    <router-view v-else />
   </v-app>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import AppHeader from '@components/layout/AppHeader.vue'
 import AppSidebar from '@components/layout/AppSidebar.vue'
 import PageContainer from '@components/layout/PageContainer.vue'
@@ -22,19 +25,22 @@ import NotificationBell from '@components/layout/NotificationBell.vue'
 import ToastContainer from '@components/common/ToastContainer.vue'
 import { useProjectStore } from '@/stores/projectStore'
 import { useOrganizationStore } from '@/stores/organizationStore'
+import { useAuthStore } from '@/stores/authStore'
 
 const drawer = ref(true)
 const organizationStore = useOrganizationStore()
 const projectStore = useProjectStore()
+const authStore = useAuthStore()
+const showAppShell = computed(() => authStore.isAuthenticated)
 
 // Initialize stores when app starts
 onMounted(async () => {
   try {
     // Initialize organization store first
     organizationStore.initialize()
-    
-    // Then initialize projects
-    await projectStore.initializeProject()
+    if (authStore.isAuthenticated) {
+      await projectStore.initializeProject()
+    }
   } catch (error) {
     console.error('Failed to initialize app:', error)
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,7 +2,10 @@ import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 import { useProjectStore } from '@/stores/projectStore'
 
 const routes: Array<RouteRecordRaw> = [
-  { path: '/', name: 'Home', component: () => import('../views/Dashboard/DashboardView.vue') },
+  { path: '/', name: 'Splash', component: () => import('../views/Splash/SplashView.vue') },
+  { path: '/login', name: 'Login', component: () => import('../views/Auth/LoginView.vue') },
+  { path: '/register', name: 'Register', component: () => import('../views/Auth/RegisterView.vue') },
+  { path: '/app', name: 'Home', component: () => import('../views/Dashboard/DashboardView.vue') },
   { path: '/projects', name: 'Projects', component: () => import('../views/Projects/ProjectsView.vue') },
   { path: '/projects/:id/home', name: 'ProjectHome', component: () => import('../views/Dashboard/DashboardView.vue') },
   { path: '/projects/:id/files', name: 'FileExplorer', component: () => import('../views/FileExplorer/FileExplorerView.vue') },

--- a/frontend/src/views/Auth/LoginView.vue
+++ b/frontend/src/views/Auth/LoginView.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="auth-form">
+    <h2>Sign In</h2>
+    <form @submit.prevent="onSubmit">
+      <input v-model="email" type="email" placeholder="Email" />
+      <input v-model="password" type="password" placeholder="Password" />
+      <button type="submit">Sign In</button>
+    </form>
+    <router-link to="/register">Create an account</router-link>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAuthStore } from '@/stores/authStore';
+import { useRouter } from 'vue-router';
+
+const email = ref('');
+const password = ref('');
+const auth = useAuthStore();
+const router = useRouter();
+
+async function onSubmit() {
+  try {
+    await auth.login(email.value, password.value);
+    router.push('/projects');
+  } catch (e) {
+    console.error(e);
+  }
+}
+</script>
+
+<style scoped>
+.auth-form {
+  max-width: 400px;
+  margin: 2rem auto;
+  text-align: center;
+}
+input {
+  display: block;
+  width: 100%;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+}
+button {
+  padding: 0.5rem 1rem;
+}
+</style>

--- a/frontend/src/views/Auth/RegisterView.vue
+++ b/frontend/src/views/Auth/RegisterView.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="auth-form">
+    <h2>Create Account</h2>
+    <form @submit.prevent="onSubmit">
+      <input v-model="orgName" placeholder="Organization Name" />
+      <input v-model="email" type="email" placeholder="Email" />
+      <input v-model="password" type="password" placeholder="Password" />
+      <button type="submit">Register</button>
+    </form>
+    <router-link to="/login">Already have an account?</router-link>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAuthStore } from '@/stores/authStore';
+import { useRouter } from 'vue-router';
+
+const orgName = ref('');
+const email = ref('');
+const password = ref('');
+const auth = useAuthStore();
+const router = useRouter();
+
+async function onSubmit() {
+  try {
+    await auth.register(orgName.value, email.value, password.value);
+    router.push('/projects');
+  } catch (e) {
+    console.error(e);
+  }
+}
+</script>
+
+<style scoped>
+.auth-form {
+  max-width: 400px;
+  margin: 2rem auto;
+  text-align: center;
+}
+input {
+  display: block;
+  width: 100%;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+}
+button {
+  padding: 0.5rem 1rem;
+}
+</style>

--- a/frontend/src/views/Splash/SplashView.vue
+++ b/frontend/src/views/Splash/SplashView.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="splash">
+    <h1>Olivine</h1>
+    <p>Knowledge management for creative production.</p>
+    <ul>
+      <li>Connect files across cloud providers</li>
+      <li>Track production assets and history</li>
+      <li>Collaborate with your team</li>
+    </ul>
+    <router-link to="/register" class="btn">Get Started</router-link>
+    <router-link to="/login" class="btn">Sign In</router-link>
+  </div>
+</template>
+
+<script setup lang="ts">
+// simple landing page
+</script>
+
+<style scoped>
+.splash {
+  max-width: 600px;
+  margin: 2rem auto;
+  text-align: center;
+}
+.btn {
+  display: inline-block;
+  margin: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add Express auth routes for user registration and login
- implement splash, login, and registration views with Pinia auth store
- conditionally render app shell only for authenticated users

## Testing
- `cd backend && npm test` *(fails: Neo4j server connection refused)*
- `cd frontend && npm test` *(fails: document/localStorage not defined in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d450b246c832f9059e9bbfe09d953