### PR TITLE
feat: add telemetry metrics

### DIFF
--- a/docs/ops/playbooks/agent-runtime.md
+++ b/docs/ops/playbooks/agent-runtime.md
@@ -1,0 +1,27 @@
+# Agent Runtime Incident Playbooks
+
+Guides for responding to common operational issues in the agent runtime.
+
+## Heartbeat Miss
+1. **Detect:** Alert fires when `olivine_heartbeats_total` has no samples for 5 minutes.
+2. **Triage:**
+   - Check agent logs for crashes or pauses.
+   - Confirm the host or container is up.
+3. **Mitigate:** Restart the agent process. If unavailable, fail over to a standby instance.
+4. **Follow up:** Collect logs and note timeline in the incident tracker.
+
+## Quota Breach
+1. **Detect:** Dashboard shows a sustained spike in `olivine_commits_total` or a custom quota metric.
+2. **Triage:**
+   - Identify offending tenant or workflow.
+   - Validate quota configuration.
+3. **Mitigate:** Throttle or disable excess workloads; raise limits only with approval.
+4. **Follow up:** Document the cause and adjust quotas or alerts as needed.
+
+## Database Outage
+1. **Detect:** Application errors or alerts indicate loss of connectivity to the primary database.
+2. **Triage:**
+   - Verify database health and network paths.
+   - Check if read replicas are available.
+3. **Mitigate:** Fail over to a healthy replica or place the service in read-only mode.
+4. **Follow up:** Engage the database team, capture postmortem notes, and update runbooks.

--- a/docs/ops/telemetry-dashboard.md
+++ b/docs/ops/telemetry-dashboard.md
@@ -1,0 +1,23 @@
+# Telemetry Dashboard
+
+This Grafana dashboard provides visibility into the Olivine runtime by exposing Prometheus metrics exported by `OlivineClient`.
+
+## Panels
+
+### Heartbeats
+- **Query:** `rate(olivine_heartbeats_total[5m])`
+- Shows the rate of heartbeats over the last five minutes.
+
+### Commits
+- **Query:** `rate(olivine_commits_total[5m])`
+- Tracks commit throughput.
+
+### Failures
+- **Query:** `rate(olivine_failures_total[5m])`
+- Monitors the rate of failed operations.
+
+### Queue Latency
+- **Query:** `histogram_quantile(0.95, sum(rate(olivine_queue_latency_seconds_bucket[5m])) by (le))`
+- Displays the 95th percentile of queue processing latency.
+
+Each panel should include legends and alerts to highlight sustained drops in heartbeats, spikes in failures, or increasing latency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "workspaces": [
         "backend",
         "frontend"
-      ]
+      ],
+      "dependencies": {
+        "prom-client": "^15.1.3"
+      }
     },
     "backend": {
       "name": "olivine-backend",
@@ -8760,6 +8763,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
@@ -9879,6 +9891,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -11676,6 +11694,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -11941,6 +11972,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "type-check": "npm run type-check:backend && npm run type-check:frontend",
     "type-check:backend": "npm --prefix backend run type-check",
     "type-check:frontend": "npm --prefix frontend run type-check"
+  },
+  "dependencies": {
+    "prom-client": "^15.1.3"
   }
 }
-
-

--- a/sdk/OlivineClient.ts
+++ b/sdk/OlivineClient.ts
@@ -1,0 +1,19 @@
+import { heartbeatCounter, commitCounter, failCounter, queueLatencyHistogram } from './telemetry';
+
+export class OlivineClient {
+  recordHeartbeat() {
+    heartbeatCounter.inc();
+  }
+
+  recordCommit() {
+    commitCounter.inc();
+  }
+
+  recordFailure() {
+    failCounter.inc();
+  }
+
+  recordQueueLatency(seconds: number) {
+    queueLatencyHistogram.observe(seconds);
+  }
+}

--- a/sdk/telemetry.ts
+++ b/sdk/telemetry.ts
@@ -1,0 +1,34 @@
+import { Counter, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+
+export const registry = new Registry();
+
+collectDefaultMetrics({ register: registry });
+
+export const heartbeatCounter = new Counter({
+  name: 'olivine_heartbeats_total',
+  help: 'Total number of heartbeats received',
+  registers: [registry],
+});
+
+export const commitCounter = new Counter({
+  name: 'olivine_commits_total',
+  help: 'Total number of commits processed',
+  registers: [registry],
+});
+
+export const failCounter = new Counter({
+  name: 'olivine_failures_total',
+  help: 'Total number of failed operations',
+  registers: [registry],
+});
+
+export const queueLatencyHistogram = new Histogram({
+  name: 'olivine_queue_latency_seconds',
+  help: 'Time spent in task queue in seconds',
+  buckets: [0.1, 0.5, 1, 5, 10],
+  registers: [registry],
+});
+
+export function metrics() {
+  return registry.metrics();
+}


### PR DESCRIPTION
## Summary
- export Prometheus metrics for heartbeats, commits, failures, and queue latency
- document Grafana telemetry dashboards and incident playbooks

## Testing
- `npx tsc --noEmit sdk/telemetry.ts sdk/OlivineClient.ts`
- `npm run lint` *(fails: Require statement not part of import statement)*
- `npm run type-check` *(fails: Cannot find type definition file for 'node')*
- `npm --prefix backend test` *(fails: Failed to connect to server)*
- `npm --prefix frontend test` *(fails: ReferenceError: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689ea907ac58832f972c4e4340117854