### PR TITLE
feat: add rate limit handling with backpressure

### DIFF
--- a/backend/src/runtime/backpressure.ts
+++ b/backend/src/runtime/backpressure.ts
@@ -1,0 +1,34 @@
+import { RateLimiter } from './rateLimiter';
+import { QuotaError, RequestResult } from '../sdk/client';
+
+type Job<T> = () => Promise<RequestResult<T>>;
+
+export class Backpressure {
+  private queue: Promise<unknown> = Promise.resolve();
+  constructor(private limiter: RateLimiter) {}
+
+  run<T>(job: Job<T>): Promise<RequestResult<T>> {
+    const execute = async (): Promise<RequestResult<T>> => {
+      // Repeat until the job succeeds without rate limit error
+      while (true) {
+        await this.limiter.wait();
+        try {
+          const result = await job();
+          this.limiter.update(result.quota, result.retryAfter);
+          return result;
+        } catch (err) {
+          if (err instanceof QuotaError) {
+            this.limiter.update(err.quota, err.retryAfter);
+            continue; // wait and retry
+          }
+          throw err;
+        }
+      }
+    };
+    const next = this.queue.then(execute);
+    // ensure subsequent jobs wait for this one
+    this.queue = next.then(() => undefined, () => undefined);
+    return next;
+  }
+}
+

--- a/backend/src/runtime/rateLimiter.ts
+++ b/backend/src/runtime/rateLimiter.ts
@@ -1,0 +1,37 @@
+import { QuotaInfo } from '../sdk/client';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class RateLimiter {
+  private remaining = Infinity;
+  private resetTime = 0; // epoch ms
+
+  async wait(): Promise<void> {
+    const now = Date.now();
+    if (this.remaining <= 0 && now < this.resetTime) {
+      await sleep(this.resetTime - now);
+      // after waiting for reset we assume quota refreshed
+      this.remaining = Infinity;
+    }
+    if (this.remaining !== Infinity) {
+      this.remaining -= 1;
+    }
+  }
+
+  update(quota?: QuotaInfo, retryAfter?: number): void {
+    if (retryAfter !== undefined) {
+      this.remaining = 0;
+      this.resetTime = Date.now() + retryAfter;
+      return;
+    }
+    if (quota?.remaining !== undefined) {
+      this.remaining = quota.remaining;
+    }
+    if (quota?.reset !== undefined) {
+      this.resetTime = quota.reset;
+    }
+  }
+}
+

--- a/backend/src/sdk/client.ts
+++ b/backend/src/sdk/client.ts
@@ -1,0 +1,66 @@
+export interface QuotaInfo {
+  limit?: number;
+  remaining?: number;
+  reset?: number; // epoch ms
+}
+
+export interface RequestResult<T = any> {
+  data: T;
+  quota?: QuotaInfo;
+  retryAfter?: number;
+}
+
+export class QuotaError extends Error {
+  status: number;
+  retryAfter?: number;
+  quota?: QuotaInfo;
+  constructor(message: string, status: number, retryAfter?: number, quota?: QuotaInfo) {
+    super(message);
+    this.name = 'QuotaError';
+    this.status = status;
+    this.retryAfter = retryAfter;
+    this.quota = quota;
+  }
+}
+
+function parseNumber(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function parseQuota(headers: Headers): QuotaInfo {
+  return {
+    limit: parseNumber(headers.get('x-quota-limit')),
+    remaining: parseNumber(headers.get('x-quota-remaining')),
+    reset: parseNumber(headers.get('x-quota-reset')),
+  };
+}
+
+export class Client {
+  private fetchFn: typeof fetch;
+
+  constructor(fetchFn: typeof fetch = globalThis.fetch) {
+    this.fetchFn = fetchFn;
+  }
+
+  async request<T = any>(url: string, init?: RequestInit): Promise<RequestResult<T>> {
+    const res = await this.fetchFn(url, init);
+    const quota = parseQuota(res.headers);
+    const retryAfter = parseNumber(res.headers.get('retry-after'));
+
+    if (res.status === 429) {
+      throw new QuotaError('Rate limit exceeded', 429, retryAfter, quota);
+    }
+
+    let data: T | undefined;
+    try {
+      data = (await res.json()) as T;
+    } catch {
+      // ignore JSON parse errors
+    }
+
+    return { data: data as T, quota, retryAfter };
+  }
+}
+

--- a/backend/src/tests/integration/rateLimit.test.ts
+++ b/backend/src/tests/integration/rateLimit.test.ts
@@ -1,0 +1,47 @@
+import { Client } from '../../sdk/client';
+import { RateLimiter } from '../../runtime/rateLimiter';
+import { Backpressure } from '../../runtime/backpressure';
+
+describe('rate limiting backpressure', () => {
+  it('backs off on 429 and resumes requests', async () => {
+    const now = Date.now();
+    const responses: Array<{ status: number; headers: Record<string, string> }> = [
+      { status: 200, headers: { 'x-quota-remaining': '2', 'x-quota-reset': String(now + 50) } },
+      { status: 200, headers: { 'x-quota-remaining': '1', 'x-quota-reset': String(now + 50) } },
+      { status: 429, headers: { 'retry-after': '100', 'x-quota-reset': String(now + 100) } },
+      { status: 200, headers: { 'x-quota-remaining': '1', 'x-quota-reset': String(now + 150) } },
+      { status: 200, headers: { 'x-quota-remaining': '0', 'x-quota-reset': String(now + 150) } },
+    ];
+
+    const fetch = jest.fn(() => {
+      const r = responses.shift();
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: r!.status,
+          headers: r!.headers,
+        })
+      );
+    });
+
+    const client = new Client(fetch as any);
+    const limiter = new RateLimiter();
+    const bp = new Backpressure(limiter);
+
+    const start = Date.now();
+    const completions: number[] = [];
+    const jobs = Array.from({ length: 4 }, () =>
+      bp.run(() => client.request('http://example.com')).then(() => {
+        completions.push(Date.now() - start);
+      })
+    );
+
+    await Promise.all(jobs);
+
+    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(completions[0]).toBeLessThan(80);
+    expect(completions[1]).toBeLessThan(80);
+    expect(completions[2]).toBeGreaterThanOrEqual(100);
+    expect(completions[3]).toBeGreaterThanOrEqual(100);
+  });
+});
+


### PR DESCRIPTION
## Summary
- parse quota headers and raise structured `QuotaError` on 429 in SDK client
- add runtime rate limiter with backpressure to retry after quota resets
- stress test ensuring requests back off then resume

## Testing
- `npx jest -c jest.rateLimit.config.js src/tests/integration/rateLimit.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689ea8fd27a0832fb89c309ad17caf48