### PR TITLE
Add CallSheet agent runtime with provenance test

### DIFF
--- a/agents/CallSheetAgent/CallSheetAgent.ts
+++ b/agents/CallSheetAgent/CallSheetAgent.ts
@@ -1,0 +1,17 @@
+import { RuntimeWorker } from '../../runtime/RuntimeWorker';
+import { OlivineClient } from '../../client/OlivineClient';
+
+export interface CallSheetEnvelope {
+  orgId: string;
+  callSheet: Record<string, unknown>;
+}
+
+export class CallSheetAgent extends RuntimeWorker<CallSheetEnvelope> {
+  constructor(private readonly client: OlivineClient) {
+    super();
+  }
+
+  protected async handle(envelope: CallSheetEnvelope): Promise<void> {
+    await this.client.createProvenanceCommit(envelope.orgId, envelope.callSheet);
+  }
+}

--- a/agents/CallSheetAgent/manifest.json
+++ b/agents/CallSheetAgent/manifest.json
@@ -1,0 +1,35 @@
+{
+  "id": "CallSheetAgent",
+  "queues": {
+    "consume": "callsheet",
+    "produce": "provenance"
+  },
+  "scopes": {
+    "read": ["callsheet"],
+    "write": ["provenance"]
+  },
+  "input": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "orgId": { "type": "string" },
+      "callSheet": { "type": "object" }
+    },
+    "required": ["orgId", "callSheet"]
+  },
+  "output": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "commit": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "orgId": { "type": "string" }
+        },
+        "required": ["id", "orgId"]
+      }
+    },
+    "required": ["commit"]
+  }
+}

--- a/client/OlivineClient.ts
+++ b/client/OlivineClient.ts
@@ -1,0 +1,15 @@
+export interface Commit {
+  id: string;
+  orgId: string;
+  payload: unknown;
+}
+
+export class OlivineClient {
+  public commits: Commit[] = [];
+
+  async createProvenanceCommit(orgId: string, payload: unknown): Promise<Commit> {
+    const commit: Commit = { id: `commit-${Math.random().toString(36).slice(2)}`, orgId, payload };
+    this.commits.push(commit);
+    return commit;
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests']
+};

--- a/runtime/RuntimeWorker.ts
+++ b/runtime/RuntimeWorker.ts
@@ -1,0 +1,16 @@
+export abstract class RuntimeWorker<TEnvelope> {
+  private queue: TEnvelope[] = [];
+
+  enqueue(envelope: TEnvelope): void {
+    this.queue.push(envelope);
+  }
+
+  async runOnce(): Promise<void> {
+    const envelope = this.queue.shift();
+    if (envelope) {
+      await this.handle(envelope);
+    }
+  }
+
+  protected abstract handle(envelope: TEnvelope): Promise<void>;
+}

--- a/tests/integration/callsheetAgent.test.ts
+++ b/tests/integration/callsheetAgent.test.ts
@@ -1,0 +1,14 @@
+import { CallSheetAgent, CallSheetEnvelope } from '../../agents/CallSheetAgent/CallSheetAgent';
+import { OlivineClient } from '../../client/OlivineClient';
+
+test('CallSheetAgent consumes envelope and commits provenance', async () => {
+  const client = new OlivineClient();
+  const agent = new CallSheetAgent(client);
+  const envelope: CallSheetEnvelope = { orgId: 'org1', callSheet: { scene: '1A' } };
+
+  agent.enqueue(envelope);
+  await agent.runOnce();
+
+  expect(client.commits).toHaveLength(1);
+  expect(client.commits[0]).toMatchObject({ orgId: 'org1', payload: { scene: '1A' } });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["agents/**/*.ts", "runtime/**/*.ts", "client/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add CallSheet agent manifest describing queues, scopes and schemas
- implement CallSheet agent using RuntimeWorker and OlivineClient
- verify envelope processing and provenance commit with integration test

## Testing
- `npx jest tests/integration/callsheetAgent.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ea8fb51c0832f8cd4defc7f432f15